### PR TITLE
Konflux: openshift-preflight: failed: HasLicense

### DIFF
--- a/Dockerfile.rhmtc
+++ b/Dockerfile.rhmtc
@@ -19,6 +19,7 @@ COPY --from=builder /workspace/_output/proxy /proxy
 
 COPY sshd_config /etc/ssh/sshd_config
 COPY stunnel.conf /etc/stunnel/stunnel.conf
+COPY LICENSE /licenses/
 
 USER 65534:65534
 WORKDIR /


### PR DESCRIPTION
"suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory."

https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-ima

> Container images must contain a “licenses” directory. Use this
> directory to add files containing software terms and conditions for your
> product and any open source software included in the image.
>
> Test name: HasLicense